### PR TITLE
Manage a DDP connection to different server

### DIFF
--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -33,7 +33,7 @@ SubsManager.prototype.subscribe = function() {
     };
   } else {
     // to support fast-render
-    if(Meteor.subscribe) {
+    if(!self.options.ddpConnection && Meteor.subscribe) {
       return Meteor.subscribe.apply(Meteor, arguments);
     }
   }
@@ -141,7 +141,7 @@ SubsManager.prototype._registerComputation = function() {
 
     var ready = true;
     _.each(self._cacheList, function(sub) {
-      sub.ready = Meteor.subscribe.apply(Meteor, sub.args).ready();
+      sub.ready = (self.options.ddpConnection || Meteor).subscribe.apply(Meteor, sub.args).ready();
       ready = ready && sub.ready;
     });
 

--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -139,9 +139,10 @@ SubsManager.prototype._registerComputation = function() {
     self._applyExpirations();
     self._applyCacheLimit();
 
+    var ddpConnection = self.options.ddpConnection || Meteor;
     var ready = true;
     _.each(self._cacheList, function(sub) {
-      sub.ready = (self.options.ddpConnection || Meteor).subscribe.apply(Meteor, sub.args).ready();
+      sub.ready = ddpConnection.subscribe.apply(ddpConnection, sub.args).ready();
       ready = ready && sub.ready;
     });
 


### PR DESCRIPTION
I have two meteor instances, an API and a client. I want the client to use SubsManager but it's hardcoded using `Meteor.subscribe`, and I want to do `DdpApi.subscribe`, which I can now do by using `new SubsManager({ddpConnection:DdpApi});`
