### PR TITLE
Unsubscribe a certain subscription

### DIFF
--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -23,9 +23,10 @@ SubsManager.prototype.subscribe = function() {
   var self = this;
   if(Meteor.isClient) {
     var args = _.toArray(arguments);
-    this._addSub(args);
+    var subKey = this._addSub(args);
 
     return {
+      key: subKey,
       ready: function() {
         self.dep.depend();
         return self._ready;
@@ -69,7 +70,7 @@ SubsManager.prototype._addSub = function(args) {
 
     // to notify the global ready()
     self._notifyChanged();
-    
+
     // no need to interfere with the current computation
     self._reRunSubs();
   }
@@ -81,6 +82,19 @@ SubsManager.prototype._addSub = function(args) {
   var index = _.indexOf(self._cacheList, sub);
   self._cacheList.splice(index, 1);
   self._cacheList.push(sub);
+  return hash;
+};
+
+SubsManager.prototype.unsubscribe = function(subKey) {
+  var sub = this._cacheMap[subKey];
+  var index = _.indexOf(this._cacheList, sub);
+  if (!sub || index == -1) {
+    return;
+  }
+
+  this._cacheList.splice(index, 1);
+  delete this._cacheMap[subKey];
+  this._reRunSubs();
 };
 
 SubsManager.prototype._reRunSubs = function() {

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   "summary": "Subscriptions Manager for Meteor",
-  "version": "1.6.3",
+  "version": "1.6.2-patch",
   "git": "https://github.com/meteorhacks/subs-manager.git",
   "name": "meteorhacks:subs-manager"
 });


### PR DESCRIPTION
At default, `SubsManager` caches all subscriptions in `_cacheList` and `_cacheMap`. It seems that there're only three ways to unsubscribe them:
- When the cache is overflown
- When subscriptions are expired
- When `clear()` is called

However, I think sometimes it might be convenience if one can selectively unsubscribe a certain subscription. Here are some relative issues:
- [Are you able to call subs.subscribe("mySub").stop() ?](https://github.com/kadirahq/subs-manager/issues/28)
- [SubsManager does not return object with the same API as Meteor.subscribe? (missing stop method)](https://github.com/kadirahq/subs-manager/issues/15)
- [Is there an easy way to expireAll() or stopAll() and resubscribeAll()?](https://github.com/kadirahq/subs-manager/issues/18)

I've made several modifications:
- When `subscribe` is called, it returns a **key**, which is essentially a JSON string of the subscription arguments. The **key** can be used to refer to the specified subscription.
- A method named `unsubscribe` is added. This method accept a subscription key, and stop it selectively.

Hope this can help.
