### PR TITLE
fix/clear method

### DIFF
--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -213,8 +213,8 @@ SubsManager.prototype.reset = function() {
 };
 
 SubsManager.prototype.clear = function() {
-  this._cacheList = []];
-  this._cacheMap = {}};
+  this._cacheList = [];
+  this._cacheMap = {};
   this._reRunSubs();
 };
 

--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -213,8 +213,8 @@ SubsManager.prototype.reset = function() {
 };
 
 SubsManager.prototype.clear = function() {
-  this._cacheList = {};
-  this._cacheMap = [];
+  this._cacheList = []];
+  this._cacheMap = {}};
   this._reRunSubs();
 };
 

--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -213,7 +213,7 @@ SubsManager.prototype.reset = function() {
 };
 
 SubsManager.prototype.clear = function() {
-  this._cacheList = [];
+  this._cacheList = {};
   this._cacheMap = [];
   this._reRunSubs();
 };


### PR DESCRIPTION
Fixed bug in clear method which was setting the _cacheMap to an array when the property was supposed to be an object.