### PR TITLE
add {canonical:true} option to EJSON.stringify

### DIFF
--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -41,9 +41,9 @@ SubsManager.prototype.subscribe = function() {
 
 SubsManager.prototype._addSub = function(args) {
   var self = this;
-  var hash = EJSON.stringify(args);
+  var hash = EJSON.stringify(args, {canonical:true});
   var subName = args[0];
-  var paramsKey = EJSON.stringify(args.slice(1));
+  var paramsKey = EJSON.stringify(args.slice(1), {canonical:true});
 
   if(!self._cacheMap[hash]) {
     var sub = {


### PR DESCRIPTION
This ensures consistent ordering of object keys in hash strings. 

Otherwise if you added the keys in a different order you'll get a new subscription. 

See docs: http://docs.meteor.com/#/full/ejson_stringify 
