### PR TITLE
account for the possibility of sub.ready() changing from true to false

### DIFF
--- a/lib/sub_manager.js
+++ b/lib/sub_manager.js
@@ -145,8 +145,8 @@ SubsManager.prototype._registerComputation = function() {
       ready = ready && sub.ready;
     });
 
-    if(ready) {
-      self._ready = true;
+    if (self._ready != ready) {
+      self._ready = ready;
       self._notifyChanged();
     }
   });


### PR DESCRIPTION
If `sub` is a Meteor subscription then it is in fact possible for `sub.ready()` to change from true to false. ~To wit, when a user logs in, all subscriptions get recomputed and are typically not ready for a brief period.~

`SubsManager` appears to be written with the assumption that `sub.ready()` can only change from false to true. This patch fixes that problem.